### PR TITLE
feat(adapter): move to using base class

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
         "react"
     ],
     "rules": {
-        "sort-imports": "error",
         "no-case-declarations": "off"
     }
 };

--- a/samples/reactJS/src/components/app.jsx
+++ b/samples/reactJS/src/components/app.jsx
@@ -3,8 +3,14 @@ import './app.css';
 import '../../../../src/webComponents/avatar';
 import '../../../../src/webComponents/smart-avatar';
 import React, {Component} from 'react';
+
 import SmartWebexTeamsAvatar from '../../../../src/reactComponents/smart-avatar';
 import { ToggleSwitch } from '@momentum-ui/react';
+
+// Adapters
+import APIAdapter from '../../../../src/adapters/APIAdapter';
+import JSONAdapter from '../../../../src/adapters/JSONAdapter';
+import SDKAdapter from '../../../../src/adapters/SDKAdapter';
 
 
 export default class ReactApp extends Component {
@@ -15,6 +21,10 @@ export default class ReactApp extends Component {
       displayWC: false,
       personID: 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS80N2MzMmQwYi0wNDQ0LTQ2MGQtOGJjZS0yMjY1YjUwMWFhYzU'
     };
+
+    this.APIAdapter = new APIAdapter();
+    this.JSONAdapter = new JSONAdapter();
+    this.SDKAdapter = new SDKAdapter();
   }
 
   getWCSmartAvatar() {
@@ -45,11 +55,11 @@ export default class ReactApp extends Component {
       <div className='container'>
         <h1> Smart React Components </h1>
         <h3> API Adapter </h3>
-        <SmartWebexTeamsAvatar personID={this.state.personID} adapter='API' />
+        <SmartWebexTeamsAvatar personID={this.state.personID} adapter={this.APIAdapter} />
         <h3> SDK Adapter </h3>
-        <SmartWebexTeamsAvatar personID={this.state.personID} adapter='SDK' />
+        <SmartWebexTeamsAvatar personID={this.state.personID} adapter={this.SDKAdapter} />
         <h3> JSON Adapter</h3>
-        <SmartWebexTeamsAvatar personID={this.state.personID} adapter='JSON'/>
+        <SmartWebexTeamsAvatar personID={this.state.personID} adapter={this.JSONAdapter} />
       </div>
     );
   }

--- a/src/adapters/APIAdapter.js
+++ b/src/adapters/APIAdapter.js
@@ -1,16 +1,17 @@
+import Adapter from './Adapter';
+
 import api from '../data/api';
 
-export default class APIAdapter {
-  constructor(callback) {
-    this.callback = callback;
-  }
-
+export default class APIAdapter extends Adapter {
   async getPerson(id) {
     const person = await api.getPerson(id);
-    this.callback(
-      {...person, 
-       src: person.avatar,
-       status: person.status === 'DoNotDisturb' ? 'dnd' : person.status});
+    
+    // Shape the data to the way the smart component needs
+    return {
+      ...person, 
+      src: person.avatar,
+      status: person.status === 'DoNotDisturb' ? 'dnd' : person.status
+    };
   }
 }
 

--- a/src/adapters/Adapter.js
+++ b/src/adapters/Adapter.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * This is the base class that adapters will inherit from.
+ * When creating your subclass adapter, make sure all methods
+ * are defined and the items returned have the proper shape.
+ */
+export default class Adapter {
+
+  /**
+   * @typedef {Object} PersonObject
+   * @property {String} src A url for the person's avatar
+   * @property {String} status dnd|ooo|available
+   */
+
+  /**
+   * 
+   * @param {String} id - ID of person to get
+   * 
+   * @returns {Promise<PersonObject>}
+   * @memberof Adapter
+   */
+  getPerson(id) {
+    return Promise.reject(new Error('getPerson has not been defined'));
+  }
+}

--- a/src/adapters/JSONAdapter.js
+++ b/src/adapters/JSONAdapter.js
@@ -1,14 +1,12 @@
+import Adapter from './Adapter';
+
 import json from '../data/json';
 
-export default class JSONAdapter {
-  constructor(callback) {
-    this.callback = callback;
-  }
-
+export default class JSONAdapter extends Adapter {
   async getPerson(id) {
     const person = await json.getPerson(id);
     
-    this.callback(person);
+    return person;
   }
 }
 

--- a/src/adapters/SDKAdapter.js
+++ b/src/adapters/SDKAdapter.js
@@ -1,24 +1,24 @@
+import Adapter from './Adapter';
+
 import sdk from '../data/sdk';
 
-export default class SDKAdapter {
-  constructor(callback) {
-    sdk.store.subscribe(async () => {
-      const person = await sdk.store.getState();
-      callback(person);
-    });
-  }
-
+export default class SDKAdapter extends Adapter {
   getPerson(id) {
-    sdk.store.dispatch({
-      type: 'PERSON_DETAILS',
-      payload: {
-        id: id
-      }
-    });
-  }
+    return new Promise((resolve) => {
+      // Subscribe and wait for our reducer
+      sdk.store.subscribe(async () => {
+        const person = await sdk.store.getState();
+        resolve(person);
+      });
 
-  disconnect() {
-    sdk.disconnect();
+      // Dispatch the fetch action
+      sdk.store.dispatch({
+        type: 'PERSON_DETAILS',
+        payload: {
+          id: id
+        }
+      });
+    });
   }
 }
 

--- a/src/reactComponents/smart-avatar.js
+++ b/src/reactComponents/smart-avatar.js
@@ -1,13 +1,10 @@
 import React, {Component} from 'react';
-import APIAdapter from '../adapters/APIAdapter';
 import {Avatar} from '@momentum-ui/react';
-import JSONAdapter from '../adapters/JSONAdapter';
 import PropTypes from 'prop-types';
-import SDKAdapter from '../adapters/SDKAdapter';
 
 const propTypes = {
   personID: PropTypes.string.isRequired,
-  adapter: PropTypes.string.isRequired,
+  adapter: PropTypes.object.isRequired,
 };
 
 export default class SmartWebexTeamsAvatar extends Component {
@@ -15,39 +12,16 @@ export default class SmartWebexTeamsAvatar extends Component {
     super(props);
 
     this.personID = props.personID;
-    this.adapterType = props.adapter;
+    this.adapter = props.adapter;
     this.state = {
       person: undefined
     };
   }
 
   componentDidMount() {
-    this.selectAdapter();
-  }
-
-  selectAdapter() {
-    switch(this.adapterType) {
-      case 'API':
-        const api = new APIAdapter(this.updatePerson.bind(this));
-        
-        api.getPerson(this.personID);
-        break;
-
-      case 'SDK':
-        const sdk = new SDKAdapter(this.updatePerson.bind(this));
-        
-        sdk.getPerson(this.personID);
-        break;
-
-      case 'JSON':
-        const json = new JSONAdapter(this.updatePerson.bind(this));
-        
-        json.getPerson(this.personID);
-        break;
-      
-      default:
-        console.error('Invalid Adapter Type. Valid Types are [API, SDK, JSON]');
-    }
+    this.adapter.getPerson(this.personID).then((person) => {
+      this.updatePerson(person);
+    })
   }
 
   updatePerson(person) {

--- a/src/webComponents/smart-avatar.js
+++ b/src/webComponents/smart-avatar.js
@@ -18,27 +18,25 @@ export default class SmartWebexTeamsAvatar extends HTMLElement {
   }
 
   selectAdapter(adapterType, personID) {
+    let adapter;
     switch(adapterType) {
       case 'API':
-        const api = new APIAdapter(this.mount.bind(this));
-        
-        api.getPerson(personID);
+        adapter = new APIAdapter();
         break;
 
       case 'SDK':
-        const sdk = new SDKAdapter(this.mount.bind(this));
-        
-        sdk.getPerson(personID);
+        adapter = new SDKAdapter();
         break;
 
       case 'JSON':
-        const json = new JSONAdapter(this.mount.bind(this));
-        
-        json.getPerson(personID);
+        adapter = new JSONAdapter();
         break;
       
       default:
         console.error('Invalid Adapter Type. Valid Types are [API, SDK, JSON]');
+    }
+    if (adapter) {
+      adapter.getPerson(personID).then((person) => this.mount(person));
     }
   }
 


### PR DESCRIPTION
My motivation behind this is that the smart components should not need to know about the adapter types. In the current setup, if a user wants to create their own adapter, they would have to update the smart component as well. 

With this PR, we define a base class that the smart components expect and call the functions within the base class to hydrate the data to the component below.

This is working for everything except the smart web component since we can only pass literals to them. Hoping you have some ideas for implementation because you're now the "web component expert" 🤣

